### PR TITLE
Stop using NOW_URL

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -43,13 +43,15 @@ module.exports = class Cache {
       headers.Authorization = `token ${token}`
     }
 
-    const { status, body } = await retry(
+    const { body } = await retry(
       async () => {
         const response = await fetch(url, { headers })
 
         if (response.status !== 200) {
           throw new Error(
-            `Tried to cache RELEASES, but failed fetching ${url}, status ${status}`
+            `Tried to cache RELEASES, but failed fetching ${url}, status ${
+              response.status
+            }`
           )
         }
 

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -9,7 +9,7 @@ const checkPlatform = require('./platform')
 
 module.exports = class Cache {
   constructor(config) {
-    const { account, repository, token, url } = config
+    const { account, repository, token, deployed_to_now, url } = config
     this.config = config
 
     if (!account || !repository) {
@@ -18,9 +18,9 @@ module.exports = class Cache {
       throw error
     }
 
-    if (token && !url) {
+    if (token && !deployed_to_now && !url) {
       const error = new Error(
-        'Neither NOW_URL, nor URL are defined, which are mandatory for private repo mode'
+        'Not deployed to Now and URL is not defined, which is mandatory for private repo mode'
       )
       error.code = 'missing_configuration_properties'
       throw error

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -98,7 +98,10 @@ module.exports = ({ cache, config }) => {
   exports.update = async (req, res) => {
     const { platform: platformName, version } = req.params
 
-    if (url.length === 0 && req.headers['x-now-deployment-url'].length > 0) {
+    if (
+      (!url || url.length === 0) &&
+      req.headers['x-now-deployment-url'].length > 0
+    ) {
       url = req.headers['x-now-deployment-url']
     }
 

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -102,7 +102,7 @@ module.exports = ({ cache, config }) => {
       (!url || url.length === 0) &&
       req.headers['x-now-deployment-url'].length > 0
     ) {
-      url = req.headers['x-now-deployment-url']
+      url = `https://${req.headers['x-now-deployment-url']}`
     }
 
     if (!valid(version)) {

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -187,11 +187,13 @@ module.exports = ({ cache, config }) => {
 
     // Filter out special platforms that should not
     // be shown on the overview page
-    Object.keys(latest.platforms).forEach(platform => {
-      if (platform === 'dmg') {
-        delete latest.platforms[platform]
-      }
-    })
+    if (latest.platforms) {
+      Object.keys(latest.platforms).forEach(platform => {
+        if (platform === 'dmg') {
+          delete latest.platforms[platform]
+        }
+      })
+    }
 
     try {
       const render = await prepareView()

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -12,7 +12,8 @@ const prepareView = require('./view')
 module.exports = ({ cache, config }) => {
   const { loadCache } = cache
   const exports = {}
-  const { token, url } = config
+  const { token } = config
+  let { url } = config
   const shouldProxyPrivateDownload =
     token && typeof token === 'string' && token.length > 0
 
@@ -21,11 +22,11 @@ module.exports = ({ cache, config }) => {
     const redirect = 'manual'
     const headers = { Accept: 'application/octet-stream' }
     const options = { headers, redirect }
-    const { api_url: rawUrl } = asset
-    const url = rawUrl.replace(
-      'https://api.github.com/',
-      `https://${token}@api.github.com/`
-    )
+    const { api_url: url } = asset
+
+    if (shouldProxyPrivateDownload) {
+      headers.Authorization = `token ${token}`
+    }
 
     fetch(url, options).then(assetRes => {
       res.setHeader('Location', assetRes.headers.get('Location'))
@@ -96,6 +97,10 @@ module.exports = ({ cache, config }) => {
 
   exports.update = async (req, res) => {
     const { platform: platformName, version } = req.params
+
+    if (url.length === 0 && req.headers['x-now-deployment-url'].length > 0) {
+      url = req.headers['x-now-deployment-url']
+    }
 
     if (!valid(version)) {
       send(res, 500, {

--- a/lib/server.js
+++ b/lib/server.js
@@ -7,10 +7,16 @@ const {
   PRE: pre,
   TOKEN: token,
   URL: PRIVATE_BASE_URL,
-  NOW_URL
+  NOW_REGION: now_region
 } = process.env
 
-const url = NOW_URL || PRIVATE_BASE_URL
+const url = PRIVATE_BASE_URL
+
+let deployed_to_now = false
+
+if (now_region && now_region.length > 0) {
+  deployed_to_now = true
+}
 
 module.exports = hazel({
   interval,
@@ -18,5 +24,6 @@ module.exports = hazel({
   repository,
   pre,
   token,
+  deployed_to_now,
   url
 })

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "lint-staged": {
     "*.js": [
-      "yarn test && :",
+      "yarn test --passWithNoTests && :",
       "prettier --single-quote --no-semi --write --no-editorconfig",
       "git add"
     ]

--- a/test/cache.test.js
+++ b/test/cache.test.js
@@ -24,6 +24,16 @@ describe('Cache', () => {
     }).toThrow(/URL/)
   })
 
+  it('should NOT throw when URL is not set but deployed_to_now is true', () => {
+    const config = {
+      account: 'zeit',
+      repository: 'hyper',
+      token: 'abc',
+      deployed_to_now: true
+    }
+    new Cache(config)
+  })
+
   it('should run without errors', () => {
     const config = {
       account: 'zeit',


### PR DESCRIPTION
`NOW_URL` is no longer set in Now 2.0 (ref: https://zeit.co/docs/v2/advanced/platform/changes-in-now-2-0/#environment-variables), so this should have been removed in the migration to Now 2.0. Instead this code now relies on `NOW_REGION` being set to detect Now deployments and gets the Now URL from the `x-now-deployment-url` request header when needed.

Also standardizes how the GitHub token is used to always be in the `Authorization` request header and fixes a crasher bug when there are no releases on GitHub.

It also passes `--passWithNoTests` to the `yarn test` call in the precommit hook or it wouldn't allow me to commit the fix in `routes.js` without creating a whole new test file for it.

Fixes #62 & #39 without the need to manually set URL to an insecure value containing your GitHub access token.