### PR TITLE
Fixed for ExpressJS

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,5 +1,5 @@
 // Packages
-const fetch = require('node-fetch')
+const fetch = require('cross-fetch')
 const retry = require('async-retry')
 const convertStream = require('stream-to-string')
 const ms = require('ms')

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,10 @@
 // Packages
-const Router = require('express').Router
+const Router = require('router')
 const finalhandler = require('finalhandler')
 const Cache = require('./cache')
 
 module.exports = config => {
-  const router = Router()
+  const router = config.router ? Router() : config.router()
   let cache = null;
 
   try {

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,7 @@ const finalhandler = require('finalhandler')
 const Cache = require('./cache')
 
 module.exports = config => {
-  const router = config.router ? Router() : config.router()
+  const router = config.router ? config.router() : Router()
   let cache = null;
 
   try {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 // Packages
-const Router = require('router')
+const Router = require('express').Router
 const finalhandler = require('finalhandler')
 const Cache = require('./cache')
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "micro": "9.3.3",
     "ms": "2.1.1",
     "node-fetch": "2.0.0",
+    "cross-fetch": "^3.0.6",
     "router": "1.3.2",
     "semver": "5.5.0",
     "stream-to-string": "1.1.0",


### PR DESCRIPTION
## Allow overriding Router
I was trying to follow the example in the HttpServer example to set this up but a few parts kept bugging. Namely that `require('router')` is not a function. I don't know if this works on other systems and is just a by product of using webpack to package a server, but I've added

`config.router` so that you can specify the direct expressjs import by doing

```js
import {Router} from 'express';
import hazel from 'hazel-server';
const server = hazel({
//other details
  router: Router
})
```
It'll still default to the 'router' package if the `config.router` option isn't specified.

## Switch node-fetch for cross-fetch
I know `cross-fetch` is worse because it's basically a super polyfill for node and browsers without the Fetch API, but `node-fetch` doesn't seem to work with webpacking either, so I figured that I'd bring a sledgehammer to hammer a nail

