### PR TITLE
Fix RELEASES downloading from private repo

### DIFF
--- a/lib/aliases.js
+++ b/lib/aliases.js
@@ -4,7 +4,8 @@ const aliases = {
   deb: ['debian'],
   rpm: ['fedora'],
   AppImage: ['appimage'],
-  dmg: ['dmg']
+  dmg: ['dmg'],
+  nupkg: ['nupkg']
 }
 
 module.exports = platform => {

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -37,19 +37,21 @@ module.exports = class Cache {
 
   async cacheReleaseList(url) {
     const { token } = this.config
-    const headers = { Accept: 'application/vnd.github.preview' }
+    const headers = { Accept: 'application/octet-stream' }
 
     if (token && typeof token === 'string' && token.length > 0) {
       headers.Authorization = `token ${token}`
     }
 
-    const { status, body } = await retry(
+    const { body } = await retry(
       async () => {
         const response = await fetch(url, { headers })
 
         if (response.status !== 200) {
           throw new Error(
-            `Tried to cache RELEASES, but failed fetching ${url}, status ${status}`
+            `Tried to cache RELEASES, but failed fetching ${url}, status ${
+              response.status
+            }`
           )
         }
 
@@ -58,7 +60,7 @@ module.exports = class Cache {
       { retries: 3 }
     )
 
-    let content = await convertStream(body)
+    const content = await convertStream(body)
     const matches = content.match(/[^ ]*\.nupkg/gim)
 
     if (matches.length === 0) {
@@ -67,11 +69,10 @@ module.exports = class Cache {
       )
     }
 
-    for (let i = 0; i < matches.length; i += 1) {
-      const nuPKG = url.replace('RELEASES', matches[i])
-      content = content.replace(matches[i], nuPKG)
-    }
-    return content
+    return content.replace(
+      matches[0],
+      `${this.config.url}/download/nupkg?update=true`
+    )
   }
 
   async refreshCache() {
@@ -139,9 +140,7 @@ module.exports = class Cache {
           if (!this.latest.files) {
             this.latest.files = {}
           }
-          this.latest.files.RELEASES = await this.cacheReleaseList(
-            browser_download_url
-          )
+          this.latest.files.RELEASES = await this.cacheReleaseList(url)
         } catch (err) {
           console.error(err)
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@ const Cache = require('./cache')
 
 module.exports = config => {
   const router = Router()
-  let cache = null;
+  let cache = null
 
   try {
     cache = new Cache(config)
@@ -14,14 +14,16 @@ module.exports = config => {
 
     if (code) {
       return (req, res) => {
-        res.statusCode = 400;
+        res.statusCode = 400
 
-        res.end(JSON.stringify({
-          error: {
-            code,
-            message
-          }
-        }))
+        res.end(
+          JSON.stringify({
+            error: {
+              code,
+              message
+            }
+          })
+        )
       }
     }
 

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -11,6 +11,6 @@ module.exports = fileName => {
     return 'darwin'
   }
 
-  const directCache = ['exe', 'dmg', 'rpm', 'deb', 'AppImage']
+  const directCache = ['exe', 'dmg', 'rpm', 'deb', 'AppImage', 'nupkg']
   return directCache.find(ext => ext === extension) || false
 }

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -1,5 +1,5 @@
 // Native
-const urlHelpers = require('url');
+const urlHelpers = require('url')
 
 // Packages
 const { send } = require('micro')

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,4 +1,4 @@
-const hazel = require('./index')
+const hazel = require('.')
 
 const {
   INTERVAL: interval,

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "lint-staged": {
     "*.js": [
-      "yarn test && :",
+      "yarn test --passWithNoTests && :",
       "prettier --single-quote --no-semi --write --no-editorconfig",
       "git add"
     ]


### PR DESCRIPTION
In the previous version, the RELEASES file was downloaded using the browser download url, which gives 404 for private repositories.