### PR TITLE
Fix example code block in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ Once it's deployed, paste the deployment address into your code (please keep in 
 const { app, autoUpdater } = require('electron')
 
 const server = <your-deployment-url>
-const feed = `${server}/update/${process.platform}/${app.getVersion()}`
+const url = `${server}/update/${process.platform}/${app.getVersion()}`
 
-autoUpdater.setFeedURL({ feed })
+autoUpdater.setFeedURL({ url })
 ```
 
 That's it! :white_check_mark:

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ const { app, autoUpdater } = require('electron')
 const server = <your-deployment-url>
 const feed = `${server}/update/${process.platform}/${app.getVersion()}`
 
-autoUpdater.setFeedURL(feed)
+autoUpdater.setFeedURL({ feed })
 ```
 
 That's it! :white_check_mark:


### PR DESCRIPTION
When we examine the official documentation and see that it is wrong to use here.

https://www.electronjs.org/docs/tutorial/updates