### PR TITLE
Use correct Environment Variable

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -20,7 +20,7 @@ module.exports = class Cache {
 
     if (token && !url) {
       const error = new Error(
-        'Neither NOW_URL, nor URL are defined, which are mandatory for private repo mode'
+        'Neither VERCEL_URL, nor URL are defined, which are mandatory for private repo mode'
       )
       error.code = 'missing_configuration_properties'
       throw error

--- a/lib/server.js
+++ b/lib/server.js
@@ -7,7 +7,7 @@ const {
   PRE: pre,
   TOKEN: token,
   URL: PRIVATE_BASE_URL,
-  NOW_URL
+  VERCEL_URL
 } = process.env
 
 const url = NOW_URL || PRIVATE_BASE_URL

--- a/lib/server.js
+++ b/lib/server.js
@@ -10,7 +10,7 @@ const {
   VERCEL_URL
 } = process.env
 
-const url = NOW_URL || PRIVATE_BASE_URL
+const url = VERCEL_URL || PRIVATE_BASE_URL
 
 module.exports = hazel({
   interval,


### PR DESCRIPTION
Instead of using the outdated `NOW_URL` Environment Variable, we'd like to use the latest one.