### PR TITLE
Fixing downloads from private repository

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -20,7 +20,7 @@ module.exports = class Cache {
 
     if (token && !url) {
       const error = new Error(
-        'Neither VERCEL_URL, nor URL are defined, which are mandatory for private repo mode'
+        'Neither NOW_URL, nor URL are defined, which are mandatory for private repo mode'
       )
       error.code = 'missing_configuration_properties'
       throw error
@@ -37,19 +37,23 @@ module.exports = class Cache {
 
   async cacheReleaseList(url) {
     const { token } = this.config
-    const headers = { Accept: 'application/vnd.github.preview' }
+    const headers = { Accept: 'application/octet-stream' }
 
     if (token && typeof token === 'string' && token.length > 0) {
       headers.Authorization = `token ${token}`
     }
 
-    const { status, body } = await retry(
+    const { body } = await retry(
       async () => {
-        const response = await fetch(url, { headers })
+        const response = await fetch(url, { headers, redirect: 'manual' })
+
+        if (response.status === 302) {
+          return await fetch(response.headers.get('location'))
+        }
 
         if (response.status !== 200) {
           throw new Error(
-            `Tried to cache RELEASES, but failed fetching ${url}, status ${status}`
+            `Tried to cache RELEASES, but failed fetching ${url}, status ${response.status}`
           )
         }
 
@@ -67,10 +71,12 @@ module.exports = class Cache {
       )
     }
 
-    for (let i = 0; i < matches.length; i += 1) {
-      const nuPKG = url.replace('RELEASES', matches[i])
-      content = content.replace(matches[i], nuPKG)
-    }
+    content = content.replace(
+      matches[0],
+      `${this.config.url}/download/latest/${matches[0]}`
+    )
+    console.log('content', content)
+
     return content
   }
 
@@ -140,7 +146,7 @@ module.exports = class Cache {
             this.latest.files = {}
           }
           this.latest.files.RELEASES = await this.cacheReleaseList(
-            browser_download_url
+            url
           )
         } catch (err) {
           console.error(err)

--- a/lib/server.js
+++ b/lib/server.js
@@ -7,10 +7,10 @@ const {
   PRE: pre,
   TOKEN: token,
   URL: PRIVATE_BASE_URL,
-  VERCEL_URL
+  NOW_URL
 } = process.env
 
-const url = VERCEL_URL || PRIVATE_BASE_URL
+const url = NOW_URL || PRIVATE_BASE_URL
 
 module.exports = hazel({
   interval,


### PR DESCRIPTION
Similar to https://github.com/vercel/hazel/pull/103 but more minimal and fixes an issue I encountered with anthrax63's solution.

The issue was that according to the GitHub docs (https://docs.github.com/en/rest/reference/repos#get-a-release-asset): 
"To download the asset's binary content, set the `Accept` header of the request to [`application/octet-stream`](https://docs.github.com/rest/overview/media-types). The API will either redirect the client to the location, or stream it directly if possible. API clients should handle both a `200` or `302` response."

If you don't manually handle the 302 response, node-fetch automatically redirects and uses the same HTTP headers as the initial request. Github API then complains that both query params & HTTP header authentication mechanism is present and throws an error. For this reason, 302 redirects are handled manually.