### PR TITLE
Fix releases route for private repos

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -37,7 +37,7 @@ module.exports = class Cache {
 
   async cacheReleaseList(url) {
     const { token } = this.config
-    const headers = { Accept: 'application/vnd.github.preview' }
+    const headers = { Accept: 'application/octet-stream' }
 
     if (token && typeof token === 'string' && token.length > 0) {
       headers.Authorization = `token ${token}`
@@ -49,7 +49,7 @@ module.exports = class Cache {
 
         if (response.status !== 200) {
           throw new Error(
-            `Tried to cache RELEASES, but failed fetching ${url}, status ${status}`
+            `Tried to cache RELEASES, but failed fetching ${url}, status ${response.status}`
           )
         }
 
@@ -140,7 +140,7 @@ module.exports = class Cache {
             this.latest.files = {}
           }
           this.latest.files.RELEASES = await this.cacheReleaseList(
-            browser_download_url
+            url
           )
         } catch (err) {
           console.error(err)


### PR DESCRIPTION
Fixed usage of wrong status variable.
Changed downloading of RELEASES to use 'url' instead of 'browser_download_url' which is unusable on private repos.