### PR TITLE
Fix authorization for private downloads

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -22,15 +22,14 @@ module.exports = ({ cache, config }) => {
   // Helpers
   const proxyPrivateDownload = (asset, req, res) => {
     const redirect = 'manual'
-    const headers = { Accept: 'application/octet-stream' }
+    const headers = {
+      Accept: 'application/octet-stream',
+      Authorization: `Bearer ${token}`
+    }
     const options = { headers, redirect }
-    const { api_url: rawUrl } = asset
-    const finalUrl = rawUrl.replace(
-      'https://api.github.com/',
-      `https://${token}@api.github.com/`
-    )
+    const { api_url: apiUrl } = asset
 
-    fetch(finalUrl, options).then(assetRes => {
+    fetch(apiUrl, options).then(assetRes => {
       res.setHeader('Location', assetRes.headers.get('Location'))
       send(res, 302)
     })


### PR DESCRIPTION
The existing authorization strategy for getting the asset download url from private repos results in a 404 error from the Github API. Passing the token as a bearer token within the Authorization header fixes the issue.