### PR TITLE
X handle has changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,4 +105,4 @@ Huge thanks to my ([@leo](https://github.com/leo)'s) friend [Andy](http://twitte
 
 ## Author
 
-Leo Lamprecht ([@notquiteleo](https://twitter.com/notquiteleo)) - [Vercel](https://vercel.com)
+Leo Lamprecht ([@leo](https://x.com/leo)) - [Vercel](https://vercel.com)


### PR DESCRIPTION
Twitter was renamed to X and my X handle changed from `@notquiteleo` to `@leo`.

This change replaces the previous broken link with the new working link.